### PR TITLE
Add front-end build step

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,6 +10,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+    - name: Install front-end dependencies
+      working-directory: front-end
+      run: npm ci
+    - name: Build front-end
+      working-directory: front-end
+      run: npm run build
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
## Summary
- verify Angular project builds by adding Node setup and build steps

## Testing
- `mvn -B -f spring/pom.xml verify` *(fails: Network is unreachable)*
- `npm ci` *(fails: dependency conflict)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d0a76048832c927779868944147a